### PR TITLE
🔀👷 Update docs.yml to trigger deployment on push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,9 @@
 name: Generate and Deploy Docs
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -31,4 +34,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: doc/api
+          publish_dir: ./doc/api


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow configuration to improve the generation and deployment of documentation.

Changes to `.github/workflows/docs.yml`:

* Added a trigger to run the workflow on pushes to the `main` branch.
* Modified the `publish_dir` path to use a relative path (`./doc/api`).